### PR TITLE
DSPDC-420 Set up artifactory publishing for storage-libs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,8 +49,6 @@ pipeline {
                     sh parts.join(' ')
                 }
             }
-
-            sh ''
         }
     }
     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
             }
         }
         stage('Publish') {
-            //when { branch 'master' }
+            when { branch 'master' }
             steps {
                 script {
                     def vaultPath = 'secret/dsp/accts/artifactory/dsdejenkins'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,7 @@ pipeline {
                 script {
                     def vaultPath = 'secret/dsp/accts/artifactory/dsdejenkins'
                     def parts = [
+                            'set +x',
                             'VAULT_TOKEN=$(cat $VAULT_TOKEN_PATH)',
                             "ARTIFACTORY_USERNAME=\$(vault read -field=username $vaultPath)",
                             "ARTIFACTORY_PASSWORD=\$(vault read -field=password $vaultPath)",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,7 @@ pipeline {
                     def vaultPath = 'secret/dsp/accts/artifactory/dsdejenkins'
                     def parts = [
                             'set +x;',
+                            'echo Publishing to Artifactory...;',
                             'export VAULT_TOKEN=$(cat $VAULT_TOKEN_PATH);',
                             "ARTIFACTORY_USERNAME=\$(vault read -field=username $vaultPath)",
                             "ARTIFACTORY_PASSWORD=\$(vault read -field=password $vaultPath)",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,8 +41,8 @@ pipeline {
                 script {
                     def vaultPath = 'secret/dsp/accts/artifactory/dsdejenkins'
                     def parts = [
-                            'set +x',
-                            'VAULT_TOKEN=$(cat $VAULT_TOKEN_PATH)',
+                            'set +x;',
+                            'export VAULT_TOKEN=$(cat $VAULT_TOKEN_PATH);',
                             "ARTIFACTORY_USERNAME=\$(vault read -field=username $vaultPath)",
                             "ARTIFACTORY_PASSWORD=\$(vault read -field=password $vaultPath)",
                             'sbt publish'

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
-// Settings to apply across the entire build.
-enablePlugins(GitVersioning)
+// Settings to apply across the entire build
 inThisBuild(
   Seq(
     organization := "org.broadinstitute",
@@ -81,10 +80,12 @@ val commonSettings = Seq(
 lazy val `monster-storage-libs` = project
   .in(file("."))
   .aggregate(gcs)
+  .settings(publish / skip := true)
 
 lazy val gcs = project
   .in(file("gcs"))
   .configs(IntegrationTest)
+  .enablePlugins(PublishPlugin)
   .settings(commonSettings)
   .settings(
     Defaults.itSettings,

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 // Settings to apply across the entire build
 inThisBuild(
   Seq(
-    organization := "org.broadinstitute",
+    organization := "org.broadinstitute.monster",
     scalaVersion := "2.12.8",
     // Auto-format
     scalafmtConfig := (ThisBuild / baseDirectory)(_ / ".scalafmt.conf").value,
@@ -79,10 +79,10 @@ val commonSettings = Seq(
 
 lazy val `monster-storage-libs` = project
   .in(file("."))
-  .aggregate(gcs)
+  .aggregate(`gcs-lib`)
   .settings(publish / skip := true)
 
-lazy val gcs = project
+lazy val `gcs-lib` = project
   .in(file("gcs"))
   .configs(IntegrationTest)
   .enablePlugins(PublishPlugin)

--- a/project/PublishPlugin.scala
+++ b/project/PublishPlugin.scala
@@ -12,12 +12,8 @@ object PublishPlugin extends AutoPlugin {
   // Make sure sbt-dynver is loaded before these settings.
   override def requires: Plugins = DynVerPlugin
 
-  /**
-    * Local name to associate with our Artifactory instance.
-    *
-    * Only used to link URLs with credentials within the build tool.
-    */
-  private val artifactoryName = "Broad Artifactory"
+  /** Realm reported by our Artifactory instance. */
+  private val artifactoryRealm = "Artifactory Realm"
 
   /** Hostname of our Artifactory instance. */
   private val artifactoryHost = "broadinstitute.jfrog.io"
@@ -39,7 +35,7 @@ object PublishPlugin extends AutoPlugin {
       username <- sys.env.get(artifactoryUsernameVar)
       password <- sys.env.get(artifactoryPasswordVar)
     } yield {
-      Credentials(artifactoryName, artifactoryHost, username, password)
+      Credentials(artifactoryRealm, artifactoryHost, username, password)
     }
 
     cred.orElse {
@@ -54,7 +50,7 @@ object PublishPlugin extends AutoPlugin {
   /** Maven-style resolver for our Artifactory instance. */
   private lazy val artifactoryResolver = Def.task {
     val target = if (isSnapshot.value) "snapshot" else "release"
-    artifactoryName at s"https://$artifactoryHost/broadinstitute/libs-$target-local"
+    artifactoryRealm at s"https://$artifactoryHost/broadinstitute/libs-$target-local"
   }
 
   // Settings to add to the entire build when this plugin is loaded on a project.

--- a/project/PublishPlugin.scala
+++ b/project/PublishPlugin.scala
@@ -1,0 +1,70 @@
+import sbt._
+import sbt.Keys._
+import sbtdynver.DynVerPlugin
+
+/**
+  * Plugin which adds publish configuration for our Artifactory instance
+  * to enabled sub-projects.
+  */
+object PublishPlugin extends AutoPlugin {
+  import DynVerPlugin.autoImport._
+
+  // Make sure sbt-dynver is loaded before these settings.
+  override def requires: Plugins = DynVerPlugin
+
+  /**
+    * Local name to associate with our Artifactory instance.
+    *
+    * Only used to link URLs with credentials within the build tool.
+    */
+  private val artifactoryName = "Broad Artifactory"
+
+  /** Hostname of our Artifactory instance. */
+  private val artifactoryHost = "broadinstitute.jfrog.io"
+
+  /** Environment variable expected to contain a username for our Artifactory. */
+  private val artifactoryUsernameVar = "ARTIFACTORY_USERNAME"
+
+  /** Environment variable expected to contain a password for our Artifactory. */
+  private val artifactoryPasswordVar = "ARTIFACTORY_PASSWORD"
+
+  /**
+    * Credentials which can authenticate the build tool with our Artifactory.
+    *
+    * We frame this as a setting so that it is loaded once at the start of the build,
+    * but within the proper DAG of settings set up by sbt.
+    */
+  private lazy val artifactoryCredentials = Def.setting {
+    val cred = for {
+      username <- sys.env.get(artifactoryUsernameVar)
+      password <- sys.env.get(artifactoryPasswordVar)
+    } yield {
+      Credentials(artifactoryName, artifactoryHost, username, password)
+    }
+
+    cred.orElse {
+      // SBT's logging comes from a task, and tasks can't be used inside settings, so we have to roll our own warning...
+      println(
+        s"[${scala.Console.YELLOW}warn${scala.Console.RESET}] $artifactoryUsernameVar or $artifactoryPasswordVar not set, publishing will fail!"
+      )
+      None
+    }
+  }
+
+  /** Maven-style resolver for our Artifactory instance. */
+  private lazy val artifactoryResolver = Def.task {
+    val target = if (isSnapshot.value) "snapshot" else "release"
+    artifactoryName at s"https://$artifactoryHost/broadinstitute/libs-$target-local"
+  }
+
+  // Settings to add to the entire build when this plugin is loaded on a project.
+  override def buildSettings: Seq[Def.Setting[_]] = Seq(
+    dynverSonatypeSnapshots := true
+  )
+
+  // Settings to add to the specific project when this plugin is loaded on that project.
+  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+    publishTo := Some(artifactoryResolver.value),
+    credentials ++= artifactoryCredentials.value.toSeq
+  )
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 // Code formatting.
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.2")
-// Enable git access in the build.
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+// Dynamically set version based on git tags / hashes.
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 // Parallelize dependnecy resolution / download.
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13-2")


### PR DESCRIPTION
Example console output of the publish job is [here](https://monster-jenkins.dsp-techops.broadinstitute.org/job/monster-storage-libs/job/dm-publish-storage-libs-DSPDC-420/6/console). For now the Jenkins logic will only publish snapshots on merges to master. We'll need to do some extra plumbing work to make tag-pushes trigger publishing a stable version.