### PR TITLE
Run "publish" stage on tag builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
             when {
                 anyOf {
                     branch 'master'
-                    buildingTag()
+                    tag pattern: 'v\\d.*', comparator: 'REGEXP'
                 }
             }
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,12 @@ pipeline {
             }
         }
         stage('Publish') {
-            when { branch 'master' }
+            when {
+                anyOf {
+                    branch 'master'
+                    buildingTag()
+                }
+            }
             steps {
                 script {
                     def vaultPath = 'secret/dsp/accts/artifactory/dsdejenkins'


### PR DESCRIPTION
With these changes, we can tag a commit with a format like `vX.Y.Z`, push the tag to GitHub, and have Jenkins re-publish the commit under the new version. Tagged builds get sent to the "releases" folder in artifactory (vs. merge builds, which get sent to "snapshots").

Only tags matching [sbt-dynver](https://github.com/dwijnand/sbt-dynver)'s version pattern get published, to avoid pointless churn.

Example build with publish: https://monster-jenkins.dsp-techops.broadinstitute.org/job/monster-storage-libs/view/tags/job/v0.0.1-test-tag-build/
Example build with no publish: https://monster-jenkins.dsp-techops.broadinstitute.org/job/monster-storage-libs/view/tags/job/test-tag-no-build/