### PR TITLE
DSPDC-498 Add method to list paths in GCS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,29 +43,29 @@ val betterMonadicForVersion = "0.3.1"
 val catsVersion = "1.6.0"
 val catsEffectVersion = "1.2.0"
 val enumeratumVersion = "1.5.13"
-val fs2Version = "1.0.4"
+val fs2Version = "1.0.5"
 
 // JSON.
 val circeVersion = "0.11.1"
-val circeDerivationVersion = "0.11.0-M1"
+val circeDerivationVersion = "0.11.0-M3"
 
 // Logging.
 val logbackVersion = "1.2.3"
 val log4CatsVersion = "0.3.0"
 
 // Web.
-val http4sVersion = "0.20.6"
+val http4sVersion = "0.20.10"
 val sshJVersion = "0.27.0"
 
 // Storage libraries.
 val commonsNetVersion = "3.6"
-val googleAuthVersion = "0.16.2"
+val googleAuthVersion = "0.17.1"
 
 // Testing.
-val googleCloudJavaVersion = "1.84.0"
+val googleCloudJavaVersion = "1.90.0"
 val scalaMockVersion = "4.4.0"
 val scalaTestVersion = "3.0.8"
-val vaultDriverVersion = "4.1.0"
+val vaultDriverVersion = "5.0.0"
 
 // Settings to apply to all sub-projects.
 // Can't be applied at the build level because of scoping rules.

--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,7 @@ val betterMonadicForVersion = "0.3.1"
 // Data types & control flow.
 val catsVersion = "1.6.0"
 val catsEffectVersion = "1.2.0"
+val enumeratumVersion = "1.5.13"
 val fs2Version = "1.0.4"
 
 // JSON.
@@ -85,13 +86,24 @@ val commonSettings = Seq(
 
 lazy val `monster-storage-libs` = project
   .in(file("."))
-  .aggregate(`gcs-lib`, `ftp-lib`, `sftp-lib`)
+  .aggregate(`common-lib`, `gcs-lib`, `ftp-lib`, `sftp-lib`)
   .settings(publish / skip := true)
+
+lazy val `common-lib` = project
+  .in(file("common"))
+  .enablePlugins(PublishPlugin)
+  .settings(commonSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.beachape" %% "enumeratum" % enumeratumVersion
+    )
+  )
 
 lazy val `gcs-lib` = project
   .in(file("gcs"))
   .configs(IntegrationTest)
   .enablePlugins(PublishPlugin)
+  .dependsOn(`common-lib`)
   .settings(commonSettings)
   .settings(
     Defaults.itSettings,
@@ -123,37 +135,39 @@ lazy val `gcs-lib` = project
   )
 
 lazy val `ftp-lib` = project
-.in(file("ftp"))
-.configs(IntegrationTest)
-.enablePlugins(PublishPlugin)
-.settings(commonSettings)
-.settings(
-  Defaults.itSettings,
-  libraryDependencies ++= Seq(
-    "ch.qos.logback" % "logback-classic" % logbackVersion,
-    "co.fs2" %% "fs2-core" % fs2Version,
-    "co.fs2" %% "fs2-io" % fs2Version,
-    "commons-net" % "commons-net" % commonsNetVersion,
-    "io.chrisdavenport" %% "log4cats-slf4j" % log4CatsVersion
-  ),
-  // All tests.
-  libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % scalaTestVersion
-  ).map(_ % s"${Test.name},${IntegrationTest.name}"),
-  // Unit tests only.
-  libraryDependencies ++= Seq(
-    "org.scalamock" %% "scalamock" % scalaMockVersion
-  ).map(_ % Test),
-  dependencyOverrides := Seq(
-    "org.typelevel" %% "cats-core" % catsVersion,
-    "org.typelevel" %% "cats-effect" % catsEffectVersion
+  .in(file("ftp"))
+  .configs(IntegrationTest)
+  .enablePlugins(PublishPlugin)
+  .dependsOn(`common-lib`)
+  .settings(commonSettings)
+  .settings(
+    Defaults.itSettings,
+    libraryDependencies ++= Seq(
+      "ch.qos.logback" % "logback-classic" % logbackVersion,
+      "co.fs2" %% "fs2-core" % fs2Version,
+      "co.fs2" %% "fs2-io" % fs2Version,
+      "commons-net" % "commons-net" % commonsNetVersion,
+      "io.chrisdavenport" %% "log4cats-slf4j" % log4CatsVersion
+    ),
+    // All tests.
+    libraryDependencies ++= Seq(
+      "org.scalatest" %% "scalatest" % scalaTestVersion
+    ).map(_ % s"${Test.name},${IntegrationTest.name}"),
+    // Unit tests only.
+    libraryDependencies ++= Seq(
+      "org.scalamock" %% "scalamock" % scalaMockVersion
+    ).map(_ % Test),
+    dependencyOverrides := Seq(
+      "org.typelevel" %% "cats-core" % catsVersion,
+      "org.typelevel" %% "cats-effect" % catsEffectVersion
+    )
   )
-)
 
 lazy val `sftp-lib` = project
   .in(file("sftp"))
   .configs(IntegrationTest)
   .enablePlugins(PublishPlugin)
+  .dependsOn(`common-lib`)
   .settings(commonSettings)
   .settings(
     Defaults.itSettings,

--- a/common/src/main/scala/org/broadinstitute/monster/storage/common/FileType.scala
+++ b/common/src/main/scala/org/broadinstitute/monster/storage/common/FileType.scala
@@ -1,0 +1,17 @@
+package org.broadinstitute.monster.storage.common
+
+import enumeratum.{Enum, EnumEntry}
+
+import scala.collection.immutable.IndexedSeq
+
+/** Common definition of file types which can exist in remote storage systems. */
+sealed trait FileType extends EnumEntry
+
+object FileType extends Enum[FileType] {
+  override val values: IndexedSeq[FileType] = findValues
+
+  case object File extends FileType
+  case object Directory extends FileType
+  case object Symlink extends FileType
+  case object Other extends FileType
+}

--- a/common/src/main/scala/org/broadinstitute/monster/storage/common/OperationStatus.scala
+++ b/common/src/main/scala/org/broadinstitute/monster/storage/common/OperationStatus.scala
@@ -4,6 +4,12 @@ import enumeratum.{Enum, EnumEntry}
 
 import scala.collection.immutable.IndexedSeq
 
+/**
+  * Convenience data type used to model the stages of performing an incremental
+  * operation against some external storage API (i.e. pulling pages of results).
+  *
+  * Only intended for use within storage-libs, should not be exposed in public APIs.
+  */
 private[storage] sealed trait OperationStatus extends EnumEntry
 
 private[storage] object OperationStatus extends Enum[OperationStatus] {

--- a/common/src/main/scala/org/broadinstitute/monster/storage/common/OperationStatus.scala
+++ b/common/src/main/scala/org/broadinstitute/monster/storage/common/OperationStatus.scala
@@ -1,0 +1,15 @@
+package org.broadinstitute.monster.storage.common
+
+import enumeratum.{Enum, EnumEntry}
+
+import scala.collection.immutable.IndexedSeq
+
+private[storage] sealed trait OperationStatus extends EnumEntry
+
+private[storage] object OperationStatus extends Enum[OperationStatus] {
+  override val values: IndexedSeq[OperationStatus] = findValues
+
+  case object NotStarted extends OperationStatus
+  case class InProgress(token: String) extends OperationStatus
+  case object Done extends OperationStatus
+}

--- a/ftp/src/it/scala/org/broadinstitute/monster/storage/ftp/FtpApiIntegrationSpec.scala
+++ b/ftp/src/it/scala/org/broadinstitute/monster/storage/ftp/FtpApiIntegrationSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.monster.storage.ftp
 
 import cats.effect.{ContextShift, IO, Timer}
 import fs2.Stream
+import org.broadinstitute.monster.storage.common.FileType
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
 import scala.concurrent.ExecutionContext
@@ -101,24 +102,24 @@ class FtpApiIntegrationSpec extends FlatSpec with Matchers with EitherValues {
 
   private val testDir = "pub/clinvar"
   private val testDirContents = List(
-    "ClinGen" -> FtpApi.Directory,
-    "ConceptID_history.txt" -> FtpApi.RegularFile,
-    "README.txt" -> FtpApi.RegularFile,
-    "README_VCF.txt" -> FtpApi.RegularFile,
-    "clinvar_public.xsd" -> FtpApi.Symlink,
-    "clinvar_submission.xsd" -> FtpApi.Symlink,
-    "disease_names" -> FtpApi.RegularFile,
-    "document_archives" -> FtpApi.Directory,
-    "gene_condition_source_id" -> FtpApi.RegularFile,
-    "presentations" -> FtpApi.Directory,
-    "release_notes" -> FtpApi.Directory,
-    "submission_templates" -> FtpApi.Directory,
-    "tab_delimited" -> FtpApi.Directory,
-    "vcf_GRCh37" -> FtpApi.Directory,
-    "vcf_GRCh38" -> FtpApi.Directory,
-    "xml" -> FtpApi.Directory,
-    "xsd_public" -> FtpApi.Directory,
-    "xsd_submission" -> FtpApi.Directory
+    "ClinGen" -> FileType.Directory,
+    "ConceptID_history.txt" -> FileType.File,
+    "README.txt" -> FileType.File,
+    "README_VCF.txt" -> FileType.File,
+    "clinvar_public.xsd" -> FileType.Symlink,
+    "clinvar_submission.xsd" -> FileType.Symlink,
+    "disease_names" -> FileType.File,
+    "document_archives" -> FileType.Directory,
+    "gene_condition_source_id" -> FileType.File,
+    "presentations" -> FileType.Directory,
+    "release_notes" -> FileType.Directory,
+    "submission_templates" -> FileType.Directory,
+    "tab_delimited" -> FileType.Directory,
+    "vcf_GRCh37" -> FileType.Directory,
+    "vcf_GRCh38" -> FileType.Directory,
+    "xml" -> FileType.Directory,
+    "xsd_public" -> FileType.Directory,
+    "xsd_submission" -> FileType.Directory
   )
   private val testEmptyDir = "pub/README"
 

--- a/ftp/src/test/scala/org/broadinstitute/monster/storage/ftp/FtpApiSpec.scala
+++ b/ftp/src/test/scala/org/broadinstitute/monster/storage/ftp/FtpApiSpec.scala
@@ -4,6 +4,7 @@ import java.io.{ByteArrayInputStream, IOException, InputStream}
 
 import cats.effect.{ContextShift, IO, Resource, Timer}
 import org.apache.commons.net.ftp.{FTPConnectionClosedException, FTPFile}
+import org.broadinstitute.monster.storage.common.FileType
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
@@ -219,10 +220,10 @@ class FtpApiSpec extends FlatSpec with Matchers with MockFactory with EitherValu
 
     contents shouldBe List.tabulate(10) { i =>
       val expectedType = (i % 4) match {
-        case FTPFile.DIRECTORY_TYPE     => FtpApi.Directory
-        case FTPFile.FILE_TYPE          => FtpApi.RegularFile
-        case FTPFile.SYMBOLIC_LINK_TYPE => FtpApi.Symlink
-        case _                          => FtpApi.Other
+        case FTPFile.DIRECTORY_TYPE     => FileType.Directory
+        case FTPFile.FILE_TYPE          => FileType.File
+        case FTPFile.SYMBOLIC_LINK_TYPE => FileType.Symlink
+        case _                          => FileType.Other
       }
       s"file-$i" -> expectedType
     }

--- a/gcs/src/main/scala/org/broadinstitute/monster/storage/gcs/GcsApi.scala
+++ b/gcs/src/main/scala/org/broadinstitute/monster/storage/gcs/GcsApi.scala
@@ -501,7 +501,7 @@ class GcsApi private[gcs] (runHttp: Request[IO] => Resource[IO, Response[IO]]) {
                     case (names, fileType) => Chunk.vector(names).map(_ -> fileType)
                   }
                   // We always return Some(_) here to append the list results to the stream.
-                  // The RHS of the tupled within is the state to use on the next iteration.
+                  // The RHS of the tuple within is the state to use on the next iteration.
                   // If a "next-token" was returned with the list results, we double-nest it
                   // so the following iteration knows:
                   //   1. It should pull another page, and
@@ -521,6 +521,7 @@ class GcsApi private[gcs] (runHttp: Request[IO] => Resource[IO, Response[IO]]) {
         // pulled all the available pages. Pass the None through to halt iteration.
         case None => IO.pure(None)
       }
+      // Make sure there's at least one element in the result stream.
       .pull
       .uncons1
       .flatMap {

--- a/gcs/src/test/scala/org/broadinstitute/monster/storage/gcs/GcsApiSpec.scala
+++ b/gcs/src/test/scala/org/broadinstitute/monster/storage/gcs/GcsApiSpec.scala
@@ -19,12 +19,12 @@ class GcsApiSpec extends FlatSpec with Matchers with OptionValues with EitherVal
   private val uploadToken = "upload-token"
   private val smallChunkSize = 16
 
-  private val readObjectURI = baseGcsUri(bucket, path, "alt" -> "media")
-  private val statObjectURI = baseGcsUri(bucket, path, "alt" -> "json")
-  private val createObjectOneShotURI = baseGcsUploadUri(bucket, "multipart")
-  private val initResumableUploadURI = baseGcsUploadUri(bucket, "resumable")
-  private val uploadURI =
-    baseGcsUploadUri(bucket, "resumable").withQueryParam("upload_id", uploadToken)
+  private val objectURI = objectUri(bucket, path)
+  private val readObjectURI = objectDataUri(bucket, path)
+  private val statObjectURI = objectMetadataUri(bucket, path)
+  private val createObjectOneShotURI = multipartUploadUri(bucket)
+  private val initResumableUploadURI = resumableUploadUri(bucket, None)
+  private val uploadURI = resumableUploadUri(bucket, Some(uploadToken))
 
   private val acceptEncodingHeader = Header("Accept-Encoding", "identity, gzip")
 
@@ -457,7 +457,7 @@ class GcsApiSpec extends FlatSpec with Matchers with OptionValues with EitherVal
     it should description in {
       val api = new GcsApi(req => {
         req.method shouldBe Method.DELETE
-        req.uri shouldBe baseGcsUri(bucket, path)
+        req.uri shouldBe objectURI
         Resource.pure(Response[IO](status = if (exists) Status.Ok else Status.NotFound))
       })
 

--- a/gcs/src/test/scala/org/broadinstitute/monster/storage/gcs/GcsApiSpec.scala
+++ b/gcs/src/test/scala/org/broadinstitute/monster/storage/gcs/GcsApiSpec.scala
@@ -4,6 +4,9 @@ import cats.effect.{IO, Resource}
 import org.apache.commons.codec.digest.DigestUtils
 import cats.implicits._
 import fs2.Stream
+import io.circe.{Json, JsonObject}
+import io.circe.syntax._
+import org.broadinstitute.monster.storage.common.FileType
 import org.http4s._
 import org.http4s.headers._
 import org.http4s.multipart.Multipart
@@ -17,7 +20,9 @@ class GcsApiSpec extends FlatSpec with Matchers with OptionValues with EitherVal
   private val bucket = "bucket"
   private val path = "the/path"
   private val uploadToken = "upload-token"
+  private val listToken = "list-token"
   private val smallChunkSize = 16
+  private val smallPageSize = 16
 
   private val objectURI = objectUri(bucket, path)
   private val readObjectURI = objectDataUri(bucket, path)
@@ -25,6 +30,8 @@ class GcsApiSpec extends FlatSpec with Matchers with OptionValues with EitherVal
   private val createObjectOneShotURI = multipartUploadUri(bucket)
   private val initResumableUploadURI = resumableUploadUri(bucket, None)
   private val uploadURI = resumableUploadUri(bucket, Some(uploadToken))
+  private val listURI = listUri(bucket, path, smallPageSize, None)
+  private val continueListURI = listUri(bucket, path, smallPageSize, Some(listToken))
 
   private val acceptEncodingHeader = Header("Accept-Encoding", "identity, gzip")
 
@@ -49,7 +56,7 @@ class GcsApiSpec extends FlatSpec with Matchers with OptionValues with EitherVal
       request.headers.toList should contain theSameElementsAs List(
         `Content-Length`.unsafeFromLong(bodyChunk.size.toLong),
         `Content-Type`(MediaType.application.json, Charset.`UTF-8`),
-        Header(UploadContentLengthHeader, expectedSize.toString()),
+        Header(UploadContentLengthHeader, expectedSize.toString),
         Header(UploadContentTypeHeader, "text/event-stream")
       )
 
@@ -415,7 +422,7 @@ class GcsApiSpec extends FlatSpec with Matchers with OptionValues with EitherVal
     } yield ()
 
     doChecks.unsafeRunSync()
-    ranges shouldBe (0 to bodyTextSize.toInt - 1 by ChunkSize).map { n =>
+    ranges shouldBe (0 until bodyTextSize.toInt by ChunkSize).map { n =>
       n -> math.min(bodyTextSize.toInt - 1, n + ChunkSize - 1)
     }
   }
@@ -590,4 +597,139 @@ class GcsApiSpec extends FlatSpec with Matchers with OptionValues with EitherVal
     start = 128L,
     recordedRatio = 0.5
   )
+
+  private def buildListResponse(
+    prefixes: Option[List[String]],
+    files: Option[List[String]],
+    nextToken: Option[String]
+  ): Json = {
+    val base = JsonObject.empty
+    val withToken = nextToken.fold(base)(t => base.add(GcsApi.ListTokenKey, t.asJson))
+    val withPrefixes =
+      prefixes.fold(withToken)(ps => withToken.add(GcsApi.ListPrefixesKey, ps.asJson))
+    val withFiles = files.fold(withPrefixes) { fs =>
+      withPrefixes.add(
+        GcsApi.ListResultsKey,
+        fs.map(f => Json.obj(GcsApi.ObjectNameKey -> f.asJson)).asJson
+      )
+    }
+    withFiles.asJson
+  }
+
+  it should "list directory contents" in {
+    val expectedPrefixes = List("foo/", "bar/")
+    val expectedFiles = List("file1", "file2")
+
+    val api = new GcsApi(req => {
+      req.method shouldBe Method.GET
+      req.uri shouldBe listURI
+
+      val body =
+        buildListResponse(Some(expectedPrefixes), Some(expectedFiles), None).noSpaces
+      Resource.pure(Response[IO](status = Status.Ok, body = Stream.emits(body.getBytes)))
+    })
+
+    val results =
+      api.listContents(bucket, path, smallPageSize).compile.toList.unsafeRunSync()
+    val expected = expectedPrefixes.map(_ -> FileType.Directory) :::
+      expectedFiles.map(_ -> FileType.File)
+    results should contain theSameElementsAs expected
+  }
+
+  it should "query all pages of list results" in {
+    val expectedPrefixes = List(List("foo/"), List("bar/"), List("baz/"))
+    val expectedFiles = List(List("file1"), List("file2"), List("file3"))
+    var pagesPulled = 0
+
+    val api = new GcsApi(req => {
+      req.method shouldBe Method.GET
+      if (pagesPulled == 0) {
+        req.uri shouldBe listURI
+      } else {
+        req.uri shouldBe continueListURI
+      }
+
+      val body = buildListResponse(
+        Some(expectedPrefixes(pagesPulled)),
+        Some(expectedFiles(pagesPulled)),
+        Some(listToken).filter(_ => pagesPulled + 1 < expectedFiles.length)
+      ).noSpaces
+      pagesPulled += 1
+      Resource.pure(Response[IO](status = Status.Ok, body = Stream.emits(body.getBytes)))
+    })
+
+    val results =
+      api.listContents(bucket, path, smallPageSize).compile.toList.unsafeRunSync()
+    val expected = expectedPrefixes.flatten.map(_ -> FileType.Directory) :::
+      expectedFiles.flatten.map(_ -> FileType.File)
+    results should contain theSameElementsAs expected
+  }
+
+  it should "not break if GCS returns no prefixes in list results" in {
+    val expectedFiles = List("file1", "file2")
+
+    val api = new GcsApi(req => {
+      req.method shouldBe Method.GET
+      req.uri shouldBe listURI
+
+      val body = buildListResponse(None, Some(expectedFiles), None).noSpaces
+      Resource.pure(Response[IO](status = Status.Ok, body = Stream.emits(body.getBytes)))
+    })
+
+    val results =
+      api.listContents(bucket, path, smallPageSize).compile.toList.unsafeRunSync()
+    val expected = expectedFiles.map(_ -> FileType.File)
+    results should contain theSameElementsAs expected
+  }
+
+  it should "not break if GCS returns only prefixes in list results" in {
+    val expectedPrefixes = List("foo/", "bar/")
+
+    val api = new GcsApi(req => {
+      req.method shouldBe Method.GET
+      req.uri shouldBe listURI
+
+      val body = buildListResponse(Some(expectedPrefixes), None, None).noSpaces
+      Resource.pure(Response[IO](status = Status.Ok, body = Stream.emits(body.getBytes)))
+    })
+
+    val results =
+      api.listContents(bucket, path, smallPageSize).compile.toList.unsafeRunSync()
+    val expected = expectedPrefixes.map(_ -> FileType.Directory)
+    results should contain theSameElementsAs expected
+  }
+
+  it should "raise a helpful error if GCS returns no list results" in {
+    val api = new GcsApi(req => {
+      req.method shouldBe Method.GET
+      req.uri shouldBe listURI
+
+      val body = buildListResponse(None, None, None).noSpaces
+      Resource.pure(Response[IO](status = Status.Ok, body = Stream.emits(body.getBytes)))
+    })
+
+    val resultsOrErr =
+      api.listContents(bucket, path, smallPageSize).compile.drain.attempt.unsafeRunSync()
+    resultsOrErr.left.value.getMessage should include(path)
+  }
+
+  it should "raise a helpful error if GCS returns an error code to a list request" in {
+    val body = "OH NO"
+    val api = new GcsApi(req => {
+      req.method shouldBe Method.GET
+      req.uri shouldBe listURI
+
+      Resource.pure(
+        Response[IO](
+          status = Status.InternalServerError,
+          body = Stream.emits(body.getBytes)
+        )
+      )
+    })
+
+    val resultsOrErr =
+      api.listContents(bucket, path, smallPageSize).compile.drain.attempt.unsafeRunSync()
+    resultsOrErr.left.value.getMessage should include(path)
+    resultsOrErr.left.value.getMessage should include(body)
+  }
 }

--- a/sftp/src/it/scala/org/broadinstitute/monster/storage/sftp/SftpApiIntegrationSpec.scala
+++ b/sftp/src/it/scala/org/broadinstitute/monster/storage/sftp/SftpApiIntegrationSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.monster.storage.sftp
 
 import cats.effect.{ContextShift, IO, Timer}
 import fs2.Stream
-import net.schmizz.sshj.sftp.FileMode
+import org.broadinstitute.monster.storage.common.FileType
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
 import scala.concurrent.ExecutionContext
@@ -124,8 +124,8 @@ class SftpApiIntegrationSpec extends FlatSpec with Matchers with EitherValues {
       .unsafeRunSync()
 
     listed should contain allElementsOf List(
-      "pub" -> FileMode.Type.DIRECTORY,
-      "readme.txt" -> FileMode.Type.REGULAR
+      "pub" -> FileType.Directory,
+      "readme.txt" -> FileType.File
     )
   }
 
@@ -136,7 +136,7 @@ class SftpApiIntegrationSpec extends FlatSpec with Matchers with EitherValues {
       .toList
       .unsafeRunSync()
 
-    listed should contain(testPath -> FileMode.Type.REGULAR)
+    listed should contain(testPath -> FileType.File)
   }
 
   it should "raise a useful error when listing a non-directory" in {

--- a/sftp/src/test/scala/org/broadinstitute/monster/storage/sftp/SftpApiSpec.scala
+++ b/sftp/src/test/scala/org/broadinstitute/monster/storage/sftp/SftpApiSpec.scala
@@ -195,7 +195,12 @@ class SftpApiSpec extends FlatSpec with Matchers with MockFactory with EitherVal
 
   it should "list remote directories" in {
     val fakeContents =
-      List(fakePath -> FileMode.Type.REGULAR, s"$fakeDir/dir" -> FileMode.Type.DIRECTORY)
+      List(
+        fakePath -> FileMode.Type.REGULAR,
+        s"$fakeDir/dir" -> FileMode.Type.DIRECTORY,
+        s"$fakeDir/link" -> FileMode.Type.SYMLINK,
+        s"$fakePath.sock" -> FileMode.Type.SOCKET_SPECIAL
+      )
     val fakeSftp = mock[SftpApi.Client]
     (fakeSftp.listRemoteDirectory _).expects(fakeDir).returning {
       IO.pure {
@@ -216,7 +221,9 @@ class SftpApiSpec extends FlatSpec with Matchers with MockFactory with EitherVal
     val contents = api.listDirectory(fakeDir).compile.toList.unsafeRunSync()
     contents should contain theSameElementsAs List(
       fakePath -> FileType.File,
-      s"$fakeDir/dir" -> FileType.Directory
+      s"$fakeDir/dir" -> FileType.Directory,
+      s"$fakeDir/link" -> FileType.Symlink,
+      s"$fakePath.sock" -> FileType.Other
     )
   }
 


### PR DESCRIPTION
I split out a `common` subproject to hold our enum for file types