### PR TITLE
DSPDC-431 Add methods for copying files within GCS

### DIFF
--- a/common/src/main/scala/org/broadinstitute/monster/storage/common/OperationStatus.scala
+++ b/common/src/main/scala/org/broadinstitute/monster/storage/common/OperationStatus.scala
@@ -15,7 +15,7 @@ private[storage] sealed trait OperationStatus extends EnumEntry
 private[storage] object OperationStatus extends Enum[OperationStatus] {
   override val values: IndexedSeq[OperationStatus] = findValues
 
-  case object NotStarted extends OperationStatus
-  case class InProgress(token: String) extends OperationStatus
-  case object Done extends OperationStatus
+  private[storage] case object NotStarted extends OperationStatus
+  private[storage] case class InProgress(token: String) extends OperationStatus
+  private[storage] case object Done extends OperationStatus
 }

--- a/gcs/src/it/scala/org/broadinstitute/monster/storage/gcs/GcsApiIntegrationSpec.scala
+++ b/gcs/src/it/scala/org/broadinstitute/monster/storage/gcs/GcsApiIntegrationSpec.scala
@@ -30,7 +30,9 @@ class GcsApiIntegrationSpec
   private implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   private implicit val t: Timer[IO] = IO.timer(ExecutionContext.global)
 
+  // Two buckets so we can test cross-bucket copy operations.
   private val bucket = "broad-dsp-monster-dev-integration-test-data"
+  private val bucket2 = "broad-dsp-monster-dev-integration-test-data2"
 
   private def bodyText(n: Long): Stream[IO, Byte] = {
     Stream
@@ -784,25 +786,42 @@ class GcsApiIntegrationSpec
       bodyChunk <- bodyText(2L * GcsApi.ChunkSize).compile.toChunk
       copiedBytes <- writeTestFile(bodyChunk).use { blob =>
         val copyTarget = s"copied/${blob.getName}"
-        for {
-          _ <- withClient(
-            _.copyObject(
-              sourceBucket = bucket,
-              sourcePath = blob.getName,
-              targetBucket = bucket,
-              targetPath = copyTarget,
-              forceCompletion = true,
-              prevToken = None
-            )
-          )
-          bytes <- IO.delay(new String(gcsClient.get(bucket, copyTarget).getContent()))
-          _ <- IO.delay(gcsClient.delete(bucket, copyTarget))
-        } yield {
-          bytes
-        }
+        Resource
+          .make(IO.pure(BlobId.of(bucket2, copyTarget))) { id =>
+            IO.delay(gcsClient.delete(id)).void
+          }
+          .use { target =>
+            withClient(
+              _.copyObject(bucket, blob.getName, target.getBucket, target.getName)
+            ) >> IO.delay(new String(gcsClient.get(target).getContent()))
+          }
       }
-      _ <- IO.delay(copiedBytes shouldBe new String(bodyChunk.toArray))
-    } yield ()
+    } yield {
+      copiedBytes shouldBe new String(bodyChunk.toArray)
+    }
+    checks.unsafeRunSync()
+  }
+
+  it should "raise a helpful error on copying a nonexistent file" in {
+    val err =
+      withClient(_.copyObject(bucket, "foo", bucket2, "bar")).attempt.unsafeRunSync()
+    val message = err.left.value.getMessage
+    message should include(bucket)
+    message should include("foo")
+    message should include(bucket2)
+    message should include("bar")
+  }
+
+  it should "raise a helpful error on copying to a nonexistent bucket" in {
+    val checks = for {
+      bodyChunk <- bodyText(2L * GcsApi.ChunkSize).compile.toChunk
+      err <- writeTestFile(bodyChunk).use { blob =>
+        withClient(_.copyObject(bucket, blob.getName, "foo", "bar")).attempt
+      }
+    } yield {
+      val message = err.left.value.getMessage
+      message should include("foo")
+    }
 
     checks.unsafeRunSync()
   }

--- a/gcs/src/main/scala/org/broadinstitute/monster/storage/gcs/GcsApi.scala
+++ b/gcs/src/main/scala/org/broadinstitute/monster/storage/gcs/GcsApi.scala
@@ -605,8 +605,8 @@ class GcsApi private[gcs] (runHttp: Request[IO] => Resource[IO, Response[IO]]) {
     * @param targetBucket GCS bucket to copy the file into
     * @param targetPath path within `targetBucket` where the copy should be written
     *
-    * @return [[OperationStatus.Done]] if the copy succeeded in one request, and
-    *         [[OperationStatus.InProgress]] otherwise
+    * @return a [[Right]] if the copy completes after this operation, otherwise a
+    *         [[Left]] containing the token to use in subsequent requests
     */
   def initializeCopy(
     sourceBucket: String,
@@ -626,8 +626,8 @@ class GcsApi private[gcs] (runHttp: Request[IO] => Resource[IO, Response[IO]]) {
     * @param prevToken continuation token returned by a previous call to the copy API
     *                  with the same arguments
     *
-    * @return [[OperationStatus.Done]] if the copy completes after this operation,
-    *         and [[OperationStatus.InProgress]] otherwise
+    * @return a [[Right]] if the copy completes after this operation, otherwise a
+    *         [[Left]] containing the token to use in subsequent requests
     */
   def incrementCopy(
     sourceBucket: String,

--- a/gcs/src/main/scala/org/broadinstitute/monster/storage/gcs/GcsApi.scala
+++ b/gcs/src/main/scala/org/broadinstitute/monster/storage/gcs/GcsApi.scala
@@ -165,6 +165,20 @@ class GcsApi private[gcs] (runHttp: Request[IO] => Resource[IO, Response[IO]]) {
       }
     }
 
+  /**
+    * Create a new object in GCS.
+    *
+    * The method used to create the new object will differ depending on the total
+    * number of bytes expected in the data stream, according to GCS recommendations.
+    *
+    * @param bucket the GCS bucket to create the new object within
+    * @param path location in `bucket` where the new object should be created
+    * @param contentType HTTP content-type of the bytes in `data`
+    * @param expectedSize total number of bytes expected to be contained in `data`
+    * @param expectedMd5 expected MD5 hash of the bytes in `data`. If given, server-side
+    *                    validation will be enabled on the upload
+    * @param data bytes to write into the new file
+    */
   def createObject(
     bucket: String,
     path: String,
@@ -537,6 +551,73 @@ class GcsApi private[gcs] (runHttp: Request[IO] => Resource[IO, Response[IO]]) {
       }
       .stream
   }
+
+  /**
+    * Copy a GCS object to another GCS path.
+    *
+    * Uses Google's more efficient "rewrite" API which shuffles bytes on their backend
+    * instead of transferring them through the client. NOTE: This still might not copy
+    * all bytes in a single request.
+    *
+    * @param sourceBucket GCS bucket containing the file to copy
+    * @param sourcePath path within `sourceBucket` pointing to the file-to-copy
+    * @param targetBucket GCS bucket to copy the file into
+    * @param targetPath path within `targetBucket` where the copy should be written
+    * @param forceCompletion if true, HTTP requests will be issued until the copy
+    *                        operation is complete. Otherwise the return value will
+    *                        depend on whether or not the initial HTTP request completed
+    *                        the entire transfer
+    * @param prevToken rewrite ID returned by a previous call to this method. If given,
+    *                  the existing rewrite operation will be continued
+    */
+  def copyObject(
+    sourceBucket: String,
+    sourcePath: String,
+    targetBucket: String,
+    targetPath: String,
+    forceCompletion: Boolean,
+    prevToken: Option[String]
+  ): IO[Either[String, Unit]] =
+    Stream
+      .unfoldEval(Option(prevToken)) {
+        case Some(rewriteId) =>
+          val request = Request[IO](
+            method = Method.POST,
+            uri =
+              rewriteUri(sourceBucket, sourcePath, targetBucket, targetPath, rewriteId)
+          )
+
+          runHttp(request).use { response =>
+            if (response.status.isSuccess) {
+              response.body.compile.toChunk.flatMap { byteChunk =>
+                val next = for {
+                  copyResponse <- parser.parseByteBuffer(byteChunk.toByteBuffer)
+                  nextToken <- copyResponse.hcursor.get[Option[String]](CopyTokenKey)
+                } yield {
+                  nextToken match {
+                    case None => Some(Right(()) -> None)
+                    case Some(token) =>
+                      if (forceCompletion) {
+                        Some(Left(token) -> Option(Option(token)))
+                      } else {
+                        Some(Left(token) -> None)
+                      }
+                  }
+                }
+
+                next.liftTo[IO]
+              }
+            } else {
+              reportError(
+                response,
+                s"Failed to copy $sourcePath in $sourceBucket to $targetPath in $targetBucket"
+              )
+            }
+          }
+        case None => IO.pure(None)
+      }
+      .compile
+      .lastOrError
 }
 
 object GcsApi {
@@ -626,6 +707,7 @@ object GcsApi {
     */
   val MaxBytesPerUploadRequest: Long = 5L * bytesPerMib
 
+  /** Multipart sub-type to include in Content-Type headers of GCS multipart upload requests. */
   val MultipartUploadSubtype = "related"
 
   /**
@@ -672,6 +754,9 @@ object GcsApi {
 
   /** Key which stores the token for the next page of results in responses to GCS "list objects" commands.  */
   val ListTokenKey: String = "nextPageToken"
+
+  /** Key which stores the token for transferring the next set of bytes in responses to GCS "rewrite" commands. */
+  val CopyTokenKey: String = "rewriteToken"
 
   /**
     * Status code returned by GCS when a request to upload bytes to a resumable
@@ -743,6 +828,18 @@ object GcsApi {
   private[gcs] def resumableUploadUri(bucket: String, id: Option[String]): Uri = {
     val base = (GcsUploadUri / bucket / "o").withQueryParam("uploadType", "resumable")
     id.fold(base)(base.withQueryParam("upload_id", _))
+  }
+
+  /** Build a URI which, when POST-ed to, will create / continue a copy operation. */
+  private[gcs] def rewriteUri(
+    sourceBucket: String,
+    sourcePath: String,
+    targetBucket: String,
+    targetPath: String,
+    id: Option[String]
+  ): Uri = {
+    val base = GcsReferenceUri / sourceBucket / "o" / sourcePath / "rewriteTo" / "b" / targetBucket / "o" / targetPath
+    id.fold(base)(base.withQueryParam("rewriteToken", _))
   }
 
   /**

--- a/gcs/src/test/scala/org/broadinstitute/monster/storage/gcs/GcsApiSpec.scala
+++ b/gcs/src/test/scala/org/broadinstitute/monster/storage/gcs/GcsApiSpec.scala
@@ -18,9 +18,12 @@ class GcsApiSpec extends FlatSpec with Matchers with OptionValues with EitherVal
   import GcsApi._
 
   private val bucket = "bucket"
+  private val bucket2 = "bucket2"
   private val path = "the/path"
+  private val path2 = "the/path2"
   private val uploadToken = "upload-token"
   private val listToken = "list-token"
+  private val copyToken = "copy-token"
   private val smallChunkSize = 16
   private val smallPageSize = 16
 
@@ -32,6 +35,8 @@ class GcsApiSpec extends FlatSpec with Matchers with OptionValues with EitherVal
   private val uploadURI = resumableUploadUri(bucket, Some(uploadToken))
   private val listURI = listUri(bucket, path, smallPageSize, None)
   private val continueListURI = listUri(bucket, path, smallPageSize, Some(listToken))
+  private val copyURI = rewriteUri(bucket, path, bucket2, path2, None)
+  private val continueCopyURI = rewriteUri(bucket, path, bucket2, path2, Some(copyToken))
 
   private val acceptEncodingHeader = Header("Accept-Encoding", "identity, gzip")
 
@@ -733,5 +738,106 @@ class GcsApiSpec extends FlatSpec with Matchers with OptionValues with EitherVal
     resultsOrErr.left.value.getMessage should include(body)
   }
 
-  
+  it should "copy objects in GCS in one shot" in {
+    val api = new GcsApi(req => {
+      req.method shouldBe Method.POST
+      req.uri shouldBe copyURI
+
+      Resource.pure(Response[IO](status = Status.Ok, body = Stream.emits("{}".getBytes)))
+    })
+
+    api.copyObject(bucket, path, bucket2, path2).unsafeRunSync()
+  }
+
+  it should "copy objects in GCS through multiple requests" in {
+    var requests = 0
+    val api = new GcsApi(req => {
+      req.method shouldBe Method.POST
+      if (requests == 0) {
+        req.uri shouldBe copyURI
+      } else {
+        req.uri shouldBe continueCopyURI
+      }
+      requests += 1
+
+      val response = if (requests < 5) {
+        Json.obj(CopyTokenKey -> copyToken.asJson)
+      } else {
+        Json.obj()
+      }
+      Resource.pure(
+        Response[IO](status = Status.Ok, body = Stream.emits(response.noSpaces.getBytes))
+      )
+    })
+
+    api.copyObject(bucket, path, bucket2, path2).unsafeRunSync()
+    requests shouldBe 5
+  }
+
+  it should "initialize long-running internal GCS copy operations" in {
+    val api = new GcsApi(req => {
+      req.method shouldBe Method.POST
+      req.uri shouldBe copyURI
+
+      val response = Json.obj(CopyTokenKey -> copyToken.asJson).noSpaces
+      Resource.pure(
+        Response[IO](status = Status.Ok, body = Stream.emits(response.getBytes))
+      )
+    })
+
+    api
+      .initializeCopy(bucket, path, bucket2, path2)
+      .unsafeRunSync() shouldBe Left(copyToken)
+  }
+
+  it should "continue long-running internal GCS copy operations" in {
+    val api = new GcsApi(req => {
+      req.method shouldBe Method.POST
+      req.uri shouldBe continueCopyURI
+
+      val response = Json.obj(CopyTokenKey -> copyToken.asJson).noSpaces
+      Resource.pure(
+        Response[IO](status = Status.Ok, body = Stream.emits(response.getBytes))
+      )
+    })
+
+    api
+      .incrementCopy(bucket, path, bucket2, path2, copyToken)
+      .unsafeRunSync() shouldBe Left(copyToken)
+  }
+
+  it should "finish long-running internal GCS copy operations" in {
+    val api = new GcsApi(req => {
+      req.method shouldBe Method.POST
+      req.uri shouldBe continueCopyURI
+
+      Resource.pure(
+        Response[IO](status = Status.Ok, body = Stream.emits("{}".getBytes))
+      )
+    })
+
+    api
+      .incrementCopy(bucket, path, bucket2, path2, copyToken)
+      .unsafeRunSync() shouldBe Right(())
+  }
+
+  it should "raise a helpful error when copy operations return an error code" in {
+    val error = "OH NO"
+    val api = new GcsApi(_ => {
+      Resource.pure(
+        Response[IO](
+          status = Status.InternalServerError,
+          body = Stream.emits(error.getBytes)
+        )
+      )
+    })
+
+    val result = api.copyObject(bucket, path, bucket2, path2).attempt.unsafeRunSync()
+    val message = result.left.value.getMessage
+    message should include(bucket)
+    message should include(path)
+    message should include(bucket2)
+    message should include(path2)
+    message should include(error)
+  }
 }

--- a/gcs/src/test/scala/org/broadinstitute/monster/storage/gcs/GcsApiSpec.scala
+++ b/gcs/src/test/scala/org/broadinstitute/monster/storage/gcs/GcsApiSpec.scala
@@ -732,4 +732,6 @@ class GcsApiSpec extends FlatSpec with Matchers with OptionValues with EitherVal
     resultsOrErr.left.value.getMessage should include(path)
     resultsOrErr.left.value.getMessage should include(body)
   }
+
+  
 }


### PR DESCRIPTION
GCS has a separate API for internal copies, but it's not too far off from how its upload / list APIs work.
1. The initial `rewrite` call moves some number of bytes. If "some number" isn't the entire file, an operation token is returned in the response
2. Subsequent calls which include the token continue the rewrite instead of launching a new one