### PR TITLE
DSPDC-509 Add a 'stat' check for SFTP files.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,12 +16,11 @@ val logbackVersion = "1.2.3"
 val log4CatsVersion = "0.3.0"
 
 // Web.
-val http4sVersion = "0.20.10"
-val sshJVersion = "0.27.0"
-
-// Storage libraries.
+val commonsCodecVersion = "1.13"
 val commonsNetVersion = "3.6"
 val googleAuthVersion = "0.17.1"
+val http4sVersion = "0.20.10"
+val sshJVersion = "0.27.0"
 
 // Testing.
 val googleCloudJavaVersion = "1.90.0"
@@ -54,6 +53,7 @@ lazy val `gcs-lib` = project
     libraryDependencies ++= Seq(
       "ch.qos.logback" % "logback-classic" % logbackVersion,
       "com.google.auth" % "google-auth-library-oauth2-http" % googleAuthVersion,
+      "commons-codec" % "commons-codec" % commonsCodecVersion,
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-derivation" % circeDerivationVersion,
       "io.circe" %% "circe-parser" % circeVersion,

--- a/common/src/main/scala/org/broadinstitute/monster/storage/common/FileAttributes.scala
+++ b/common/src/main/scala/org/broadinstitute/monster/storage/common/FileAttributes.scala
@@ -1,0 +1,9 @@
+package org.broadinstitute.monster.storage.common
+
+/**
+  * Minimal attributes that are useful to know about a remote file.
+  *
+  * @param size number of bytes in the file
+  * @param md5 MD5-hash of the file's contents, if known
+  */
+case class FileAttributes(size: Long, md5: Option[String])

--- a/gcs/src/main/scala/org/broadinstitute/monster/storage/gcs/GcsApi.scala
+++ b/gcs/src/main/scala/org/broadinstitute/monster/storage/gcs/GcsApi.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.monster.storage.gcs
 
 import cats.effect.IO
 import fs2.Stream
-import org.broadinstitute.monster.storage.common.FileType
+import org.broadinstitute.monster.storage.common.{FileAttributes, FileType}
 import org.http4s.headers._
 
 /** Client which can perform I/O operations against Google Cloud Storage. */
@@ -34,7 +34,7 @@ trait GcsApi {
     * @return a boolean indicating if an object exists at `path` in `bucket`, and the
     *         md5 of the object if Google calculated one during the upload
     */
-  def statObject(bucket: String, path: String): IO[(Boolean, Option[String])]
+  def statObject(bucket: String, path: String): IO[Option[FileAttributes]]
 
   /**
     * Create a new object in GCS.

--- a/gcs/src/test/scala/org/broadinstitute/monster/storage/gcs/JsonHttpGcsApiSpec.scala
+++ b/gcs/src/test/scala/org/broadinstitute/monster/storage/gcs/JsonHttpGcsApiSpec.scala
@@ -6,6 +6,7 @@ import cats.implicits._
 import fs2.Stream
 import io.circe.{Json, JsonObject}
 import io.circe.syntax._
+import org.apache.commons.codec.binary.{Base64, Hex}
 import org.broadinstitute.monster.storage.common.{FileAttributes, FileType}
 import org.http4s._
 import org.http4s.headers._
@@ -319,14 +320,15 @@ class JsonHttpGcsApiSpec
   }
 
   it should "return the md5 of an existing object" in {
-    val theMd5 = "abcdefg"
+    val theMd5 = "abcdef123456"
+    val b64Md5 = Base64.encodeBase64String(Hex.decodeHex(theMd5))
 
     val api = buildApi { req =>
       req.method shouldBe Method.GET
       req.uri shouldBe statObjectURI
 
       val response = Json
-        .obj(ObjectMd5Key -> theMd5.asJson, ObjectSizeKey -> smallChunkSize.asJson)
+        .obj(ObjectMd5Key -> b64Md5.asJson, ObjectSizeKey -> smallChunkSize.asJson)
         .noSpaces
       Resource.pure(Response[IO](body = Stream.emits(response.getBytes())))
     }

--- a/gcs/src/test/scala/org/broadinstitute/monster/storage/gcs/JsonHttpGcsApiSpec.scala
+++ b/gcs/src/test/scala/org/broadinstitute/monster/storage/gcs/JsonHttpGcsApiSpec.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 import fs2.Stream
 import io.circe.{Json, JsonObject}
 import io.circe.syntax._
-import org.broadinstitute.monster.storage.common.FileType
+import org.broadinstitute.monster.storage.common.{FileAttributes, FileType}
 import org.http4s._
 import org.http4s.headers._
 import org.http4s.multipart.Multipart
@@ -291,19 +291,22 @@ class JsonHttpGcsApiSpec
   }
 
   // statObject
-  it should "return true if a GCS object exists" in {
+  it should "return attributes for GCS objects that exist" in {
     val api = buildApi { req =>
       req.method shouldBe Method.GET
       req.uri shouldBe statObjectURI
-      Resource.pure(Response[IO](body = Stream.emits("{}".getBytes())))
+
+      val response = Json.obj(ObjectSizeKey -> smallChunkSize.asJson).noSpaces
+      Resource.pure(Response[IO](body = Stream.emits(response.getBytes())))
     }
 
     api
       .statObject(bucket, path)
-      .unsafeRunSync() shouldBe (true -> None)
+      .unsafeRunSync()
+      .value shouldBe FileAttributes(smallChunkSize.toLong, None)
   }
 
-  it should "return false if a GCS object does not exist" in {
+  it should "return no attributes for non-existing GCS objects" in {
     val api = buildApi { req =>
       req.method shouldBe Method.GET
       req.uri shouldBe statObjectURI
@@ -312,7 +315,7 @@ class JsonHttpGcsApiSpec
 
     api
       .statObject(bucket, path)
-      .unsafeRunSync() shouldBe (false -> None)
+      .unsafeRunSync() shouldBe None
   }
 
   it should "return the md5 of an existing object" in {
@@ -321,16 +324,17 @@ class JsonHttpGcsApiSpec
     val api = buildApi { req =>
       req.method shouldBe Method.GET
       req.uri shouldBe statObjectURI
-      Resource.pure(
-        Response[IO](
-          body = Stream.emits(s"""{"$ObjectMd5Key": "$theMd5"}""".getBytes())
-        )
-      )
+
+      val response = Json
+        .obj(ObjectMd5Key -> theMd5.asJson, ObjectSizeKey -> smallChunkSize.asJson)
+        .noSpaces
+      Resource.pure(Response[IO](body = Stream.emits(response.getBytes())))
     }
 
     api
       .statObject(bucket, path)
-      .unsafeRunSync() shouldBe (true -> Some(theMd5))
+      .unsafeRunSync()
+      .value shouldBe FileAttributes(smallChunkSize.toLong, Some(theMd5))
   }
 
   private def singleShotApiRequest(stringBody: String, md5: Option[String]): GcsApi =

--- a/sftp/src/main/scala/org/broadinstitute/monster/storage/sftp/SftpApi.scala
+++ b/sftp/src/main/scala/org/broadinstitute/monster/storage/sftp/SftpApi.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.monster.storage.sftp
 
 import cats.effect.IO
 import fs2.Stream
-import org.broadinstitute.monster.storage.common.FileType
+import org.broadinstitute.monster.storage.common.{FileAttributes, FileType}
 
 /**
   * Client which can perform I/O operations against an SFTP site.
@@ -26,6 +26,13 @@ trait SftpApi {
     fromByte: Long = 0L,
     untilByte: Option[Long] = None
   ): Stream[IO, Byte]
+
+  /**
+    * Check if an SFTP file exists, returning useful attributes about it if so.
+    *
+    * @param path path within the configured SFTP site pointing to the potential file.
+    */
+  def statFile(path: String): IO[Option[FileAttributes]]
 
   /**
     * List the contents of an SFTP directory.


### PR DESCRIPTION
This is needed for the SFTP->GCS Transporter agent, because we need to know the total size of the source file to initialize a resumable upload in the target.

I also introduced another common type to capture the output of `stat` calls, and updated the GCS API to use it.