### PR TITLE
DSPDC-546 Bump dependencies to latest versions.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,24 +2,24 @@
 val betterMonadicForVersion = "0.3.1"
 
 // Data types & control flow.
-val catsVersion = "1.6.0"
-val catsEffectVersion = "1.2.0"
+val catsVersion = "2.0.0"
+val catsEffectVersion = "2.0.0"
 val enumeratumVersion = "1.5.13"
-val fs2Version = "1.0.5"
+val fs2Version = "2.0.1"
 
 // JSON.
-val circeVersion = "0.11.1"
-val circeDerivationVersion = "0.11.0-M3"
+val circeVersion = "0.12.1"
+val circeDerivationVersion = "0.12.0-M6"
 
 // Logging.
 val logbackVersion = "1.2.3"
-val log4CatsVersion = "0.3.0"
+val log4CatsVersion = "1.0.0"
 
 // Web.
 val commonsCodecVersion = "1.13"
 val commonsNetVersion = "3.6"
 val googleAuthVersion = "0.17.1"
-val http4sVersion = "0.20.10"
+val http4sVersion = "0.21.0-M5"
 val sshJVersion = "0.27.0"
 
 // Testing.
@@ -57,7 +57,7 @@ lazy val `gcs-lib` = project
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-derivation" % circeDerivationVersion,
       "io.circe" %% "circe-parser" % circeVersion,
-      "org.http4s" %% "http4s-blaze-client" % http4sVersion
+      "org.http4s" %% "http4s-client" % http4sVersion
     ),
     // All tests.
     libraryDependencies ++= Seq(
@@ -66,7 +66,8 @@ lazy val `gcs-lib` = project
     // Integration tests only.
     libraryDependencies ++= Seq(
       "com.bettercloud" % "vault-java-driver" % vaultDriverVersion,
-      "com.google.cloud" % "google-cloud-storage" % googleCloudJavaVersion
+      "com.google.cloud" % "google-cloud-storage" % googleCloudJavaVersion,
+      "org.http4s" %% "http4s-blaze-client" % http4sVersion
     ).map(_ % IntegrationTest),
     // Pin important transitive dependencies to avoid chaos.
     dependencyOverrides := Seq(

--- a/ftp/src/it/scala/org/broadinstitute/monster/storage/ftp/CommonsNetFtpApiIntegrationSpec.scala
+++ b/ftp/src/it/scala/org/broadinstitute/monster/storage/ftp/CommonsNetFtpApiIntegrationSpec.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.monster.storage.ftp
 
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.{Blocker, ContextShift, IO, Timer}
 import fs2.Stream
 import org.broadinstitute.monster.storage.common.FileType
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
@@ -124,7 +124,9 @@ class CommonsNetFtpApiIntegrationSpec extends FlatSpec with Matchers with Either
   private val testEmptyDir = "pub/README"
 
   private def getClient(info: FtpConnectionInfo = testInfo): Stream[IO, FtpApi] =
-    Stream.resource(CommonsNetFtpApi.build(info, ExecutionContext.global))
+    Stream.resource(
+      CommonsNetFtpApi.build(info, Blocker.liftExecutionContext(ExecutionContext.global))
+    )
 
   behavior of "CommonsNetFtpApi"
 

--- a/ftp/src/test/scala/org/broadinstitute/monster/storage/ftp/CommonsNetFtpApiSpec.scala
+++ b/ftp/src/test/scala/org/broadinstitute/monster/storage/ftp/CommonsNetFtpApiSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.monster.storage.ftp
 
 import java.io.{ByteArrayInputStream, IOException, InputStream}
 
-import cats.effect.{ContextShift, IO, Resource, Timer}
+import cats.effect.{Blocker, ContextShift, IO, Resource, Timer}
 import org.apache.commons.net.ftp.{FTPConnectionClosedException, FTPFile}
 import org.broadinstitute.monster.storage.common.FileType
 import org.scalamock.scalatest.MockFactory
@@ -24,6 +24,7 @@ class CommonsNetFtpApiSpec
   private val fakePath = s"$fakeDir/file"
   private val fakeContents = "some text"
   private val fakeChunkSize = 128
+  private val blocker = Blocker.liftExecutionContext(ExecutionContext.global)
 
   behavior of "CommonsNetFtpApi"
 
@@ -35,7 +36,7 @@ class CommonsNetFtpApiSpec
 
     val api = new CommonsNetFtpApi(
       fakeFtp,
-      ExecutionContext.global,
+      blocker,
       fakeChunkSize,
       0,
       Duration.Zero
@@ -53,7 +54,7 @@ class CommonsNetFtpApiSpec
 
     val api = new CommonsNetFtpApi(
       fakeFtp,
-      ExecutionContext.global,
+      blocker,
       fakeChunkSize,
       0,
       Duration.Zero
@@ -72,7 +73,7 @@ class CommonsNetFtpApiSpec
 
     val api = new CommonsNetFtpApi(
       fakeFtp,
-      ExecutionContext.global,
+      blocker,
       fakeChunkSize,
       0,
       Duration.Zero
@@ -94,7 +95,7 @@ class CommonsNetFtpApiSpec
 
     val api = new CommonsNetFtpApi(
       fakeFtp,
-      ExecutionContext.global,
+      blocker,
       fakeChunkSize,
       0,
       Duration.Zero
@@ -118,7 +119,7 @@ class CommonsNetFtpApiSpec
 
     val api = new CommonsNetFtpApi(
       fakeFtp,
-      ExecutionContext.global,
+      blocker,
       fakeChunkSize,
       0,
       Duration.Zero
@@ -169,7 +170,7 @@ class CommonsNetFtpApiSpec
 
     val api = new CommonsNetFtpApi(
       fakeFtp,
-      ExecutionContext.global,
+      blocker,
       fakeChunkSize,
       1,
       Duration.Zero
@@ -203,7 +204,7 @@ class CommonsNetFtpApiSpec
 
     val api = new CommonsNetFtpApi(
       fakeFtp,
-      ExecutionContext.global,
+      blocker,
       fakeChunkSize,
       1,
       Duration.Zero
@@ -239,7 +240,7 @@ class CommonsNetFtpApiSpec
 
     val api = new CommonsNetFtpApi(
       fakeFtp,
-      ExecutionContext.global,
+      blocker,
       fakeChunkSize,
       1,
       Duration.Zero
@@ -270,7 +271,7 @@ class CommonsNetFtpApiSpec
 
     val api = new CommonsNetFtpApi(
       fakeFtp,
-      ExecutionContext.global,
+      blocker,
       fakeChunkSize,
       0,
       Duration.Zero
@@ -297,7 +298,7 @@ class CommonsNetFtpApiSpec
 
     val api = new CommonsNetFtpApi(
       fakeFtp,
-      ExecutionContext.global,
+      blocker,
       fakeChunkSize,
       0,
       Duration.Zero
@@ -314,7 +315,7 @@ class CommonsNetFtpApiSpec
 
     val api = new CommonsNetFtpApi(
       fakeFtp,
-      ExecutionContext.global,
+      blocker,
       fakeChunkSize,
       0,
       Duration.Zero

--- a/gcs/src/it/scala/org/broadinstitute/monster/storage/gcs/JsonHttpGcsApiIntegrationSpec.scala
+++ b/gcs/src/it/scala/org/broadinstitute/monster/storage/gcs/JsonHttpGcsApiIntegrationSpec.scala
@@ -13,8 +13,8 @@ import fs2.{Chunk, Stream}
 import org.apache.commons.codec.digest.DigestUtils
 import org.broadinstitute.monster.storage.common.FileType
 import org.http4s.{MediaType, Status}
-import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.client.middleware.Logger
+import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.headers._
 import org.scalatest.{BeforeAndAfterAll, EitherValues, FlatSpec, Matchers, OptionValues}
 

--- a/gcs/src/main/scala/org/broadinstitute/monster/storage/gcs/JsonHttpGcsApi.scala
+++ b/gcs/src/main/scala/org/broadinstitute/monster/storage/gcs/JsonHttpGcsApi.scala
@@ -18,6 +18,7 @@ import org.broadinstitute.monster.storage.common.{
 import org.http4s._
 import org.http4s.client.Client
 import org.http4s.headers._
+import org.http4s.implicits._
 import org.http4s.multipart.Boundary
 import org.http4s.util.CaseInsensitiveString
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0
+sbt.version=1.3.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,4 +14,4 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "monster-sbt-plugins" % "0.1.1")
+addSbtPlugin("org.broadinstitute.monster" % "monster-sbt-plugins" % "0.2.1")

--- a/sftp/src/it/scala/org/broadinstitute/monster/storage/sftp/SshjSftpApiIntegrationSpec.scala
+++ b/sftp/src/it/scala/org/broadinstitute/monster/storage/sftp/SshjSftpApiIntegrationSpec.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.monster.storage.sftp
 
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.{Blocker, ContextShift, IO, Timer}
 import fs2.Stream
 import org.broadinstitute.monster.storage.common.{FileAttributes, FileType}
 import org.scalatest.{EitherValues, FlatSpec, Matchers, OptionValues}
@@ -36,7 +36,9 @@ class SshjSftpApiIntegrationSpec
   ).mkString("\r\n")
 
   def getClient(info: SftpLoginInfo = testLogin): Stream[IO, SftpApi] =
-    Stream.resource(SshjSftpApi.build(info, ExecutionContext.global))
+    Stream.resource(
+      SshjSftpApi.build(info, Blocker.liftExecutionContext(ExecutionContext.global))
+    )
 
   behavior of "SftpApi"
 


### PR DESCRIPTION
The only source-breaking change here is the addition of `Blocker` as a distinct type to mark thread pools for blocking I/O.